### PR TITLE
feat: add context cancellation for graceful shutdown

### DIFF
--- a/internal/service/weather.go
+++ b/internal/service/weather.go
@@ -57,15 +57,14 @@ func NewWeatherWithDeps(cfg *config.Config, c WeatherCache, fetcher WeatherFetch
 	}
 }
 
-// GetWeather retrieves weather data, using cache if available.
-func (w *Weather) GetWeather() (*weather.Response, error) {
+func (w *Weather) GetWeather(ctx context.Context) (*weather.Response, error) {
 	if w.cache != nil {
 		if data := w.cache.Get(w.cfg.Location); data != nil {
 			return data, nil
 		}
 	}
 
-	data, err := w.fetchFromAPI()
+	data, err := w.fetchFromAPI(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -79,9 +78,7 @@ func (w *Weather) GetWeather() (*weather.Response, error) {
 	return data, nil
 }
 
-func (w *Weather) fetchFromAPI() (*weather.Response, error) {
-	ctx := context.Background()
-
+func (w *Weather) fetchFromAPI(ctx context.Context) (*weather.Response, error) {
 	return w.fetcher.Fetch(ctx, weather.FetchOptions{
 		Location:   w.cfg.Location,
 		Days:       w.cfg.Days,

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func runWeather(ctx context.Context, location string) {
 	data, err := svc.GetWeather(ctx)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
-			fmt.Fprintln(os.Stderr, "\nRequest cancelled.")
+			fmt.Fprintln(os.Stderr, "\nRequest canceled.")
 			os.Exit(130)
 		}
 		cli.ExitWithError(fmt.Errorf("error fetching weather: %w", err))


### PR DESCRIPTION
## Summary
- Add signal handling for graceful Ctrl+C cancellation
- Propagate context through the API call chain
- Provide user feedback on cancellation

## Changes
- **main.go**: Create context with `signal.NotifyContext` for interrupt signals
- **service/weather.go**: `GetWeather` now accepts `context.Context` parameter
- **Exit code 130**: Standard Unix exit code for SIGINT termination

## User Experience
Before:
```
^C (hangs or cryptic error)
```

After:
```
^C
Request cancelled.
```

## Testing
- Added `TestGetWeather_ContextCancellation` test case
- All existing tests updated to pass context