### PR TITLE
refactor(display): add io.Writer support for testability

### DIFF
--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -2,6 +2,8 @@ package ui
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strings"
 
 	"github.com/enescakir/emoji"
@@ -141,5 +143,9 @@ func CreateBorder(maxLen int) string {
 }
 
 func Spacer() {
-	fmt.Print("\n\n")
+	fmt.Fprint(os.Stdout, "\n\n")
+}
+
+func SpacerTo(w io.Writer) {
+	fmt.Fprint(w, "\n\n")
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -143,9 +143,9 @@ func CreateBorder(maxLen int) string {
 }
 
 func Spacer() {
-	fmt.Fprint(os.Stdout, "\n\n")
+	_, _ = fmt.Fprint(os.Stdout, "\n\n")
 }
 
 func SpacerTo(w io.Writer) {
-	fmt.Fprint(w, "\n\n")
+	_, _ = fmt.Fprint(w, "\n\n")
 }

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -143,7 +143,7 @@ func CreateBorder(maxLen int) string {
 }
 
 func Spacer() {
-	_, _ = fmt.Fprint(os.Stdout, "\n\n")
+	SpacerTo(os.Stdout)
 }
 
 func SpacerTo(w io.Writer) {

--- a/internal/weather/display.go
+++ b/internal/weather/display.go
@@ -2,6 +2,8 @@ package weather
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"time"
 
@@ -237,25 +239,28 @@ func (d *Display) Warnings() string {
 	return output.String()
 }
 
-// Render outputs the complete weather display to stdout.
 func (d *Display) Render() {
-	fmt.Print(d.Heading())
-	ui.Spacer()
+	d.RenderTo(os.Stdout)
+}
 
-	fmt.Print(d.Time())
-	ui.Spacer()
+func (d *Display) RenderTo(w io.Writer) {
+	fmt.Fprint(w, d.Heading())
+	ui.SpacerTo(w)
 
-	fmt.Print(d.CurrentConditions())
-	ui.Spacer()
+	fmt.Fprint(w, d.Time())
+	ui.SpacerTo(w)
 
-	fmt.Print(d.HourlyForecast())
-	ui.Spacer()
+	fmt.Fprint(w, d.CurrentConditions())
+	ui.SpacerTo(w)
 
-	fmt.Print(d.DailyForecast())
-	ui.Spacer()
+	fmt.Fprint(w, d.HourlyForecast())
+	ui.SpacerTo(w)
 
-	fmt.Print(d.Twilight())
-	ui.Spacer()
+	fmt.Fprint(w, d.DailyForecast())
+	ui.SpacerTo(w)
 
-	fmt.Print(d.Warnings())
+	fmt.Fprint(w, d.Twilight())
+	ui.SpacerTo(w)
+
+	fmt.Fprint(w, d.Warnings())
 }

--- a/internal/weather/display.go
+++ b/internal/weather/display.go
@@ -244,23 +244,23 @@ func (d *Display) Render() {
 }
 
 func (d *Display) RenderTo(w io.Writer) {
-	fmt.Fprint(w, d.Heading())
+	_, _ = fmt.Fprint(w, d.Heading())
 	ui.SpacerTo(w)
 
-	fmt.Fprint(w, d.Time())
+	_, _ = fmt.Fprint(w, d.Time())
 	ui.SpacerTo(w)
 
-	fmt.Fprint(w, d.CurrentConditions())
+	_, _ = fmt.Fprint(w, d.CurrentConditions())
 	ui.SpacerTo(w)
 
-	fmt.Fprint(w, d.HourlyForecast())
+	_, _ = fmt.Fprint(w, d.HourlyForecast())
 	ui.SpacerTo(w)
 
-	fmt.Fprint(w, d.DailyForecast())
+	_, _ = fmt.Fprint(w, d.DailyForecast())
 	ui.SpacerTo(w)
 
-	fmt.Fprint(w, d.Twilight())
+	_, _ = fmt.Fprint(w, d.Twilight())
 	ui.SpacerTo(w)
 
-	fmt.Fprint(w, d.Warnings())
+	_, _ = fmt.Fprint(w, d.Warnings())
 }

--- a/internal/weather/display.go
+++ b/internal/weather/display.go
@@ -243,6 +243,8 @@ func (d *Display) Render() {
 	d.RenderTo(os.Stdout)
 }
 
+// RenderTo outputs the complete weather display to the given writer.
+// This enables testability by allowing output capture with a bytes.Buffer.
 func (d *Display) RenderTo(w io.Writer) {
 	_, _ = fmt.Fprint(w, d.Heading())
 	ui.SpacerTo(w)

--- a/internal/weather/display_test.go
+++ b/internal/weather/display_test.go
@@ -1,6 +1,7 @@
 package weather
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -265,5 +266,62 @@ func TestDailyForecast_MultipleDays(t *testing.T) {
 	// Should contain condition text
 	if !strings.Contains(result, "Light rain") {
 		t.Errorf("DailyForecast() = %q, want string containing 'Light rain'", result)
+	}
+}
+
+func TestRenderTo(t *testing.T) {
+	data := &api.Response{
+		Location: api.Location{
+			Name:      "London",
+			Country:   "UK",
+			LocalTime: "2025-01-06 12:00",
+		},
+		Current: api.Current{
+			TempC:         15,
+			FeelsLike:     13,
+			Humidity:      75,
+			WindSpeed:     10,
+			WindDirection: "SW",
+			Condition:     api.Condition{Text: "Cloudy"},
+		},
+		Forecast: api.Forecast{
+			Forecastday: []api.ForecastDay{
+				{
+					Date: "2025-01-06",
+					Astro: api.Astro{
+						Sunrise: "07:30 AM",
+						Sunset:  "04:30 PM",
+					},
+					Hour: []api.Hour{},
+				},
+			},
+		},
+		Alerts: api.Alerts{Alert: []api.Alert{}},
+	}
+
+	display, err := NewDisplay(data, true)
+	if err != nil {
+		t.Fatalf("unexpected error creating display: %v", err)
+	}
+
+	var buf bytes.Buffer
+	display.RenderTo(&buf)
+
+	output := buf.String()
+
+	if !strings.Contains(output, "London") {
+		t.Error("RenderTo() output missing location name")
+	}
+	if !strings.Contains(output, "UK") {
+		t.Error("RenderTo() output missing country")
+	}
+	if !strings.Contains(output, "Cloudy") {
+		t.Error("RenderTo() output missing condition")
+	}
+	if !strings.Contains(output, "Sunrise") {
+		t.Error("RenderTo() output missing sunrise")
+	}
+	if !strings.Contains(output, "Sunset") {
+		t.Error("RenderTo() output missing sunset")
 	}
 }


### PR DESCRIPTION
## Summary
- Add `RenderTo(io.Writer)` method for flexible output destination
- Add `SpacerTo(io.Writer)` helper in ui package
- Add comprehensive test demonstrating output capture

## Changes
- **display.go**: New `RenderTo(io.Writer)` method, `Render()` now delegates to it
- **ui.go**: New `SpacerTo(io.Writer)` function
- **display_test.go**: New `TestRenderTo` test capturing output to buffer

## Benefits
1. **Testability**: Can capture output in tests without stdout manipulation
2. **Flexibility**: Future support for writing to files, pipes, or other destinations
3. **Backward Compatible**: Existing `Render()` call still works unchanged

## Example Test Usage
```go
var buf bytes.Buffer
display.RenderTo(&buf)
output := buf.String()
// Assert on output contents
```