### PR TITLE
refactor(di): add App struct and config factory for testability

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -1,0 +1,62 @@
+// Package app provides the application orchestration layer with dependency injection.
+package app
+
+import (
+	"context"
+	"io"
+
+	"github.com/jtotty/weather-cli/internal/api/weather"
+	"github.com/jtotty/weather-cli/internal/config"
+	"github.com/jtotty/weather-cli/internal/service"
+	weatherdisplay "github.com/jtotty/weather-cli/internal/weather"
+)
+
+// WeatherService defines the interface for getting weather data.
+type WeatherService interface {
+	GetWeather(ctx context.Context) (*weather.Response, error)
+}
+
+// App contains the application dependencies and orchestrates the weather workflow.
+type App struct {
+	config  *config.Config
+	service WeatherService
+	output  io.Writer
+}
+
+// NewApp creates an App with production dependencies.
+func NewApp(cfg *config.Config, output io.Writer) *App {
+	return &App{
+		config:  cfg,
+		service: service.NewWeather(cfg),
+		output:  output,
+	}
+}
+
+// NewAppWithDeps creates an App with injected dependencies (for testing).
+func NewAppWithDeps(cfg *config.Config, svc WeatherService, output io.Writer) *App {
+	return &App{
+		config:  cfg,
+		service: svc,
+		output:  output,
+	}
+}
+
+// Run executes the weather fetch and display workflow.
+func (a *App) Run(ctx context.Context, location string) error {
+	if location != "" {
+		a.config.SetLocation(location)
+	}
+
+	data, err := a.service.GetWeather(ctx)
+	if err != nil {
+		return err
+	}
+
+	display, err := weatherdisplay.NewDisplay(data, a.config.IsLocal)
+	if err != nil {
+		return err
+	}
+
+	display.RenderTo(a.output)
+	return nil
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/jtotty/weather-cli/internal/api/weather"
 	"github.com/jtotty/weather-cli/internal/config"
-	"github.com/jtotty/weather-cli/internal/service"
 	weatherdisplay "github.com/jtotty/weather-cli/internal/weather"
 )
 
@@ -23,17 +22,9 @@ type App struct {
 	output  io.Writer
 }
 
-// NewApp creates an App with production dependencies.
-func NewApp(cfg *config.Config, output io.Writer) *App {
-	return &App{
-		config:  cfg,
-		service: service.NewWeather(cfg),
-		output:  output,
-	}
-}
-
-// NewAppWithDeps creates an App with injected dependencies (for testing).
-func NewAppWithDeps(cfg *config.Config, svc WeatherService, output io.Writer) *App {
+// NewApp creates an App with the provided dependencies.
+// All dependencies are explicit - the caller is responsible for creating them.
+func NewApp(cfg *config.Config, svc WeatherService, output io.Writer) *App {
 	return &App{
 		config:  cfg,
 		service: svc,

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -102,7 +102,7 @@ func TestApp_Run(t *testing.T) {
 			}
 			var buf bytes.Buffer
 
-			application := NewAppWithDeps(cfg, mockSvc, &buf)
+			application := NewApp(cfg, mockSvc, &buf)
 			err := application.Run(context.Background(), tt.location)
 
 			if (err != nil) != tt.wantErr {
@@ -133,7 +133,7 @@ func TestApp_Run_LocationSetsIsLocalFalse(t *testing.T) {
 	mockSvc := &mockWeatherService{response: validWeatherResponse()}
 	var buf bytes.Buffer
 
-	application := NewAppWithDeps(cfg, mockSvc, &buf)
+	application := NewApp(cfg, mockSvc, &buf)
 	err := application.Run(context.Background(), "Paris")
 
 	if err != nil {
@@ -153,7 +153,7 @@ func TestApp_Run_ContextCancellation(t *testing.T) {
 	mockSvc := &mockWeatherService{err: context.Canceled}
 	var buf bytes.Buffer
 
-	application := NewAppWithDeps(cfg, mockSvc, &buf)
+	application := NewApp(cfg, mockSvc, &buf)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
@@ -167,15 +167,16 @@ func TestApp_Run_ContextCancellation(t *testing.T) {
 
 func TestNewApp(t *testing.T) {
 	cfg := config.NewWithAPIKey("test-api-key")
+	mockSvc := &mockWeatherService{response: validWeatherResponse()}
 	var buf bytes.Buffer
 
-	application := NewApp(cfg, &buf)
+	application := NewApp(cfg, mockSvc, &buf)
 
 	if application.config != cfg {
 		t.Error("expected config to be set")
 	}
-	if application.service == nil {
-		t.Error("expected service to be created")
+	if application.service != mockSvc {
+		t.Error("expected service to be set")
 	}
 	if application.output != &buf {
 		t.Error("expected output to be set")

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,0 +1,183 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jtotty/weather-cli/internal/api/weather"
+	"github.com/jtotty/weather-cli/internal/config"
+)
+
+type mockWeatherService struct {
+	response *weather.Response
+	err      error
+}
+
+func (m *mockWeatherService) GetWeather(_ context.Context) (*weather.Response, error) {
+	return m.response, m.err
+}
+
+func validWeatherResponse() *weather.Response {
+	return &weather.Response{
+		Location: weather.Location{
+			Name:      "London",
+			Country:   "United Kingdom",
+			LocalTime: "2024-01-15 14:30",
+		},
+		Current: weather.Current{
+			TempC:         12.5,
+			FeelsLike:     10.2,
+			Humidity:      75,
+			WindSpeed:     8.5,
+			WindDirection: "SW",
+			Condition:     weather.Condition{Text: "Partly cloudy"},
+		},
+		Forecast: weather.Forecast{
+			Forecastday: []weather.ForecastDay{
+				{
+					Date: "2024-01-15",
+					Day: weather.Day{
+						MaxTempC:     14.0,
+						MinTempC:     8.0,
+						Condition:    weather.Condition{Text: "Cloudy"},
+						ChanceOfRain: 30,
+					},
+					Hour: []weather.Hour{
+						{TimeEpoch: 1705320000, TempC: 10.0, Condition: weather.Condition{Text: "Clear"}},
+					},
+					Astro: weather.Astro{Sunrise: "07:45 AM", Sunset: "04:30 PM"},
+				},
+			},
+		},
+	}
+}
+
+func TestApp_Run(t *testing.T) {
+	tests := []struct {
+		name            string
+		location        string
+		mockResponse    *weather.Response
+		mockErr         error
+		wantErr         bool
+		wantInOutput    []string
+		wantNotInOutput []string
+	}{
+		{
+			name:         "successful weather fetch",
+			location:     "London",
+			mockResponse: validWeatherResponse(),
+			wantErr:      false,
+			wantInOutput: []string{"London", "United Kingdom"},
+		},
+		{
+			name:         "empty location uses config default",
+			location:     "",
+			mockResponse: validWeatherResponse(),
+			wantErr:      false,
+			wantInOutput: []string{"London"},
+		},
+		{
+			name:     "service error propagates",
+			location: "InvalidCity",
+			mockErr:  errors.New("API error: city not found"),
+			wantErr:  true,
+		},
+		{
+			name:     "context canceled error",
+			location: "London",
+			mockErr:  context.Canceled,
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.NewWithAPIKey("test-api-key")
+			mockSvc := &mockWeatherService{
+				response: tt.mockResponse,
+				err:      tt.mockErr,
+			}
+			var buf bytes.Buffer
+
+			application := NewAppWithDeps(cfg, mockSvc, &buf)
+			err := application.Run(context.Background(), tt.location)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Run() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.wantErr {
+				return
+			}
+
+			output := buf.String()
+			for _, want := range tt.wantInOutput {
+				if !strings.Contains(output, want) {
+					t.Errorf("Run() output should contain %q, got %q", want, output)
+				}
+			}
+		})
+	}
+}
+
+func TestApp_Run_LocationSetsIsLocalFalse(t *testing.T) {
+	cfg := config.NewWithAPIKey("test-api-key")
+	if !cfg.IsLocal {
+		t.Fatal("expected IsLocal to be true initially")
+	}
+
+	mockSvc := &mockWeatherService{response: validWeatherResponse()}
+	var buf bytes.Buffer
+
+	application := NewAppWithDeps(cfg, mockSvc, &buf)
+	err := application.Run(context.Background(), "Paris")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.IsLocal {
+		t.Error("expected IsLocal to be false after setting location")
+	}
+	if cfg.Location != "Paris" {
+		t.Errorf("expected location to be Paris, got %s", cfg.Location)
+	}
+}
+
+func TestApp_Run_ContextCancellation(t *testing.T) {
+	cfg := config.NewWithAPIKey("test-api-key")
+	mockSvc := &mockWeatherService{err: context.Canceled}
+	var buf bytes.Buffer
+
+	application := NewAppWithDeps(cfg, mockSvc, &buf)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := application.Run(ctx, "London")
+
+	if !errors.Is(err, context.Canceled) {
+		t.Errorf("expected context.Canceled error, got %v", err)
+	}
+}
+
+func TestNewApp(t *testing.T) {
+	cfg := config.NewWithAPIKey("test-api-key")
+	var buf bytes.Buffer
+
+	application := NewApp(cfg, &buf)
+
+	if application.config != cfg {
+		t.Error("expected config to be set")
+	}
+	if application.service == nil {
+		t.Error("expected service to be created")
+	}
+	if application.output != &buf {
+		t.Error("expected output to be set")
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,22 +14,26 @@ type Config struct {
 	IsLocal    bool
 }
 
-func New() (*Config, error) {
-	cfg := &Config{
+// NewWithAPIKey creates a Config with the provided API key.
+// Use this for testing or when the API key is obtained externally.
+func NewWithAPIKey(apiKey string) *Config {
+	return &Config{
+		APIKey:     apiKey,
 		Location:   "auto:ip",
 		Days:       7,
 		IncludeAQI: true,
 		Alerts:     true,
 		IsLocal:    true,
 	}
+}
 
+// New creates a Config by loading the API key from credentials.
+func New() (*Config, error) {
 	apiKey, err := credentials.GetAPIKey()
 	if err != nil {
 		return nil, err
 	}
-
-	cfg.APIKey = apiKey
-	return cfg, nil
+	return NewWithAPIKey(apiKey), nil
 }
 
 func (c *Config) SetLocation(location string) {

--- a/internal/service/weather.go
+++ b/internal/service/weather.go
@@ -29,8 +29,18 @@ type Weather struct {
 	fetcher WeatherFetcher
 }
 
-// NewWeather creates a new Weather service with default cache and API client.
-func NewWeather(cfg *config.Config) *Weather {
+// NewWeather creates a Weather service with the provided dependencies.
+func NewWeather(cfg *config.Config, c WeatherCache, fetcher WeatherFetcher) *Weather {
+	return &Weather{
+		cfg:     cfg,
+		cache:   c,
+		fetcher: fetcher,
+	}
+}
+
+// NewDefaultDeps creates the default cache and fetcher for production use.
+// Returns nil cache if creation fails (with warning printed to stderr).
+func NewDefaultDeps(cfg *config.Config) (WeatherCache, WeatherFetcher) {
 	weatherCache, err := cache.New(cache.DefaultTTL)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: cache unavailable: %v\n", err)
@@ -41,20 +51,7 @@ func NewWeather(cfg *config.Config) *Weather {
 		cacheImpl = weatherCache
 	}
 
-	return &Weather{
-		cfg:     cfg,
-		cache:   cacheImpl,
-		fetcher: weather.NewClient(cfg.APIKey),
-	}
-}
-
-// NewWeatherWithDeps creates a Weather service with injected dependencies (for testing).
-func NewWeatherWithDeps(cfg *config.Config, c WeatherCache, fetcher WeatherFetcher) *Weather {
-	return &Weather{
-		cfg:     cfg,
-		cache:   c,
-		fetcher: fetcher,
-	}
+	return cacheImpl, weather.NewClient(cfg.APIKey)
 }
 
 func (w *Weather) GetWeather(ctx context.Context) (*weather.Response, error) {

--- a/internal/service/weather_test.go
+++ b/internal/service/weather_test.go
@@ -63,7 +63,10 @@ func TestNewWeather(t *testing.T) {
 		Alerts:     true,
 	}
 
-	svc := NewWeather(cfg)
+	mockCache := newMockCache()
+	mockFetcher := &mockFetcher{}
+
+	svc := NewWeather(cfg, mockCache, mockFetcher)
 
 	if svc == nil {
 		t.Fatal("NewWeather() returned nil")
@@ -71,6 +74,14 @@ func TestNewWeather(t *testing.T) {
 
 	if svc.cfg != cfg {
 		t.Error("NewWeather() did not store config reference")
+	}
+
+	if svc.cache != mockCache {
+		t.Error("NewWeather() did not store cache reference")
+	}
+
+	if svc.fetcher != mockFetcher {
+		t.Error("NewWeather() did not store fetcher reference")
 	}
 }
 
@@ -91,7 +102,7 @@ func TestGetWeather_CacheHit(t *testing.T) {
 
 	mockFetcher := &mockFetcher{}
 
-	svc := NewWeatherWithDeps(cfg, mockCache, mockFetcher)
+	svc := NewWeather(cfg, mockCache, mockFetcher)
 
 	result, err := svc.GetWeather(context.Background())
 	if err != nil {
@@ -128,7 +139,7 @@ func TestGetWeather_CacheMiss(t *testing.T) {
 	mockCache := newMockCache() // Empty cache
 	mockFetcher := &mockFetcher{response: apiResponse}
 
-	svc := NewWeatherWithDeps(cfg, mockCache, mockFetcher)
+	svc := NewWeather(cfg, mockCache, mockFetcher)
 
 	result, err := svc.GetWeather(context.Background())
 	if err != nil {
@@ -182,7 +193,7 @@ func TestGetWeather_APIError(t *testing.T) {
 	mockCache := newMockCache()
 	mockFetcher := &mockFetcher{err: errors.New("API error: location not found")}
 
-	svc := NewWeatherWithDeps(cfg, mockCache, mockFetcher)
+	svc := NewWeather(cfg, mockCache, mockFetcher)
 
 	result, err := svc.GetWeather(context.Background())
 
@@ -215,7 +226,7 @@ func TestGetWeather_CacheSetError(t *testing.T) {
 
 	mockFetcher := &mockFetcher{response: apiResponse}
 
-	svc := NewWeatherWithDeps(cfg, mockCache, mockFetcher)
+	svc := NewWeather(cfg, mockCache, mockFetcher)
 
 	result, err := svc.GetWeather(context.Background())
 	if err != nil {
@@ -240,7 +251,7 @@ func TestGetWeather_NilCache(t *testing.T) {
 
 	mockFetcher := &mockFetcher{response: apiResponse}
 
-	svc := NewWeatherWithDeps(cfg, nil, mockFetcher)
+	svc := NewWeather(cfg, nil, mockFetcher)
 
 	result, err := svc.GetWeather(context.Background())
 	if err != nil {
@@ -266,7 +277,7 @@ func TestGetWeather_ContextCancellation(t *testing.T) {
 	mockCache := newMockCache()
 	mockFetcher := &mockFetcher{err: context.Canceled}
 
-	svc := NewWeatherWithDeps(cfg, mockCache, mockFetcher)
+	svc := NewWeather(cfg, mockCache, mockFetcher)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/main.go
+++ b/main.go
@@ -45,7 +45,8 @@ func runWeather(ctx context.Context, location string) {
 		cli.ExitWithError(err)
 	}
 
-	svc := service.NewWeather(cfg)
+	cache, fetcher := service.NewDefaultDeps(cfg)
+	svc := service.NewWeather(cfg, cache, fetcher)
 	application := app.NewApp(cfg, svc, os.Stdout)
 	if err := application.Run(ctx, location); err != nil {
 		if errors.Is(err, context.Canceled) {

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jtotty/weather-cli/internal/cli"
 	"github.com/jtotty/weather-cli/internal/config"
 	"github.com/jtotty/weather-cli/internal/credentials"
+	"github.com/jtotty/weather-cli/internal/service"
 )
 
 var version = "dev"
@@ -44,7 +45,8 @@ func runWeather(ctx context.Context, location string) {
 		cli.ExitWithError(err)
 	}
 
-	application := app.NewApp(cfg, os.Stdout)
+	svc := service.NewWeather(cfg)
+	application := app.NewApp(cfg, svc, os.Stdout)
 	if err := application.Run(ctx, location); err != nil {
 		if errors.Is(err, context.Canceled) {
 			fmt.Fprintln(os.Stderr, "\nRequest canceled.")

--- a/main.go
+++ b/main.go
@@ -7,11 +7,10 @@ import (
 	"os"
 	"os/signal"
 
+	"github.com/jtotty/weather-cli/internal/app"
 	"github.com/jtotty/weather-cli/internal/cli"
 	"github.com/jtotty/weather-cli/internal/config"
 	"github.com/jtotty/weather-cli/internal/credentials"
-	"github.com/jtotty/weather-cli/internal/service"
-	"github.com/jtotty/weather-cli/internal/weather"
 )
 
 var version = "dev"
@@ -45,26 +44,14 @@ func runWeather(ctx context.Context, location string) {
 		cli.ExitWithError(err)
 	}
 
-	if location != "" {
-		cfg.SetLocation(location)
-	}
-
-	svc := service.NewWeather(cfg)
-	data, err := svc.GetWeather(ctx)
-	if err != nil {
+	application := app.NewApp(cfg, os.Stdout)
+	if err := application.Run(ctx, location); err != nil {
 		if errors.Is(err, context.Canceled) {
 			fmt.Fprintln(os.Stderr, "\nRequest canceled.")
 			os.Exit(130)
 		}
 		cli.ExitWithError(fmt.Errorf("error fetching weather: %w", err))
 	}
-
-	display, err := weather.NewDisplay(data, cfg.IsLocal)
-	if err != nil {
-		cli.ExitWithError(fmt.Errorf("error creating display: %w", err))
-	}
-
-	display.Render()
 }
 
 func loadConfig() (*config.Config, error) {


### PR DESCRIPTION
- Add config.NewWithAPIKey() factory function for testing without
  environment variable manipulation
- Create internal/app package with App struct that accepts injected
  dependencies via NewAppWithDeps()
- Refactor main.go to use App for weather workflow orchestration
- Add comprehensive tests for App including error handling and
  context cancellation

This enables integration testing of the full weather workflow with
mock services while keeping production code unchanged.