### PR TITLE
refactor: delete dead exported surface in cache, credentials, ui

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -104,27 +104,6 @@ func (c *Cache) Set(location string, data *weather.Response) error {
 	return c.save()
 }
 
-func (c *Cache) Clear() error {
-	c.Entries = make(map[string]*Entry)
-	return c.save()
-}
-
-func (c *Cache) Path() string {
-	return c.path
-}
-
-func (c *Cache) Stats() (total, valid, expired int) {
-	total = len(c.Entries)
-	for _, entry := range c.Entries {
-		if entry.IsValid(c.ttl) {
-			valid++
-		} else {
-			expired++
-		}
-	}
-	return
-}
-
 func (c *Cache) load() error {
 	data, err := os.ReadFile(c.path)
 	if err != nil {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -151,24 +151,6 @@ func TestCache(t *testing.T) {
 			t.Errorf("Get() = %v, want nil for expired entry", got)
 		}
 	})
-
-	t.Run("clear", func(t *testing.T) {
-		// Add a fresh entry
-		err := cache.Set("Paris", mockResponse)
-		if err != nil {
-			t.Fatalf("Set() error = %v", err)
-		}
-
-		err = cache.Clear()
-		if err != nil {
-			t.Fatalf("Clear() error = %v", err)
-		}
-
-		got := cache.Get("Paris")
-		if got != nil {
-			t.Errorf("Get() after Clear() = %v, want nil", got)
-		}
-	})
 }
 
 func TestCachePersistence(t *testing.T) {
@@ -306,47 +288,6 @@ func TestCacheCorruptedFile(t *testing.T) {
 	}
 }
 
-func TestCacheStats(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "weather-cli-cache-stats-test")
-	if err != nil {
-		t.Fatalf("failed to create temp dir: %v", err)
-	}
-	defer func() { _ = os.RemoveAll(tmpDir) }()
-
-	cache := &Cache{
-		Entries: make(map[string]*Entry),
-		path:    filepath.Join(tmpDir, "cache.json"),
-		ttl:     1 * time.Hour,
-	}
-
-	mockResponse := &weather.Response{
-		Location: weather.Location{Name: "London"},
-	}
-
-	// Add some entries
-	_ = cache.Set("London", mockResponse)
-	_ = cache.Set("Paris", mockResponse)
-
-	// Add an expired entry manually
-	cache.Entries["expired"] = &Entry{
-		Location: "Expired",
-		Data:     mockResponse,
-		CachedAt: time.Now().Add(-2 * time.Hour),
-	}
-
-	total, valid, expired := cache.Stats()
-
-	if total != 3 {
-		t.Errorf("Stats() total = %d, want 3", total)
-	}
-	if valid != 2 {
-		t.Errorf("Stats() valid = %d, want 2", valid)
-	}
-	if expired != 1 {
-		t.Errorf("Stats() expired = %d, want 1", expired)
-	}
-}
-
 func TestCacheMaxEntries(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "weather-cli-cache-max-test")
 	if err != nil {
@@ -374,7 +315,7 @@ func TestCacheMaxEntries(t *testing.T) {
 	}
 
 	// Cache should not exceed maxCacheEntries
-	total, _, _ := cache.Stats()
+	total := len(cache.Entries)
 	if total > maxCacheEntries {
 		t.Errorf("Cache size = %d, want <= %d", total, maxCacheEntries)
 	}

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -103,8 +103,3 @@ func IsKeyringAvailable() bool {
 
 	return false
 }
-
-func HasStoredAPIKey() bool {
-	key, err := keyring.Get(serviceName, apiKeyName)
-	return err == nil && key != ""
-}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -3,7 +3,6 @@ package ui
 import (
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/enescakir/emoji"
@@ -140,10 +139,6 @@ func CreateBorder(maxLen int) string {
 	}
 
 	return border.String()
-}
-
-func Spacer() {
-	SpacerTo(os.Stdout)
 }
 
 func SpacerTo(w io.Writer) {


### PR DESCRIPTION
Removes exported symbols with no production callers, along with the tests that pinned them:

- `Cache.Clear`, `Cache.Path`, `Cache.Stats` (internal/cache)
- `credentials.HasStoredAPIKey` (internal/credentials)
- `ui.Spacer` stdout variant (internal/ui) - `SpacerTo(io.Writer)` remains

`TestCacheMaxEntries` now checks `len(cache.Entries)` directly instead of the deleted `Stats()`.

Verified: `go build`, `go test -race ./...`, and golangci-lint v2.6.2 (CI-pinned version) all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)