### PR TITLE
refactor: credential store seam with keyring adapter and in-memory fake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ CLI weather tool using WeatherAPI.com. Go 1.25, single binary, OS keyring for cr
 │   ├── cache/                   # File-based cache (30min TTL)
 │   ├── cli/                     # Arg parsing, help, setup wizard
 │   ├── config/                  # Config struct, URL builder
-│   ├── credentials/             # OS keyring (zalando/go-keyring)
+│   ├── credentials/             # Credential store: Store interface, keyring adapter, env override, fake
 │   ├── service/                 # Weather service (orchestrates cache + API)
 │   ├── ui/                      # Icons, borders, ANSI colors
 │   └── weather/                 # Display formatting
@@ -46,6 +46,8 @@ golangci-lint run                # Lint (v2)
 | `Config` | config/config.go | API key, location, days |
 | `Display` | weather/display.go | Formats weather output |
 | `Parse` | cli/cli.go | Arg parsing, returns Command |
+| `Store` | credentials/credentials.go | Credential store seam: `Get`/`Set`/`Delete`/`Available` |
+| `LoadConfig` | cli/setup.go | Config loading incl. guided setup on missing key |
 
 ## Code Style
 - **Imports**: stdlib > external > internal
@@ -80,7 +82,7 @@ golangci-lint run                # Lint (v2)
 - Never suppress errors silently - always log or return
 
 ## Gotchas
-- API key stored in OS keyring, not config file - use `credentials.Get()`
+- API key stored in OS keyring, not config file - access it via the `credentials.Store` interface (main wires `NewEnvOverride(NewKeyring())`; tests use `credentials.Fake`)
 - Cache uses `float32` for weather data, not `float64`
 - `internal/` packages can't be imported externally
 - golangci-lint v2 syntax differs from v1 - check `.golangci.yml`

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,26 @@
+# Domain Glossary
+
+## Credential Store
+
+The single answer to "where does the API key come from".
+Owns retrieval, storage, deletion, availability, and precedence between sources.
+Not responsible for how a human enters a key - that is the Setup Wizard's job.
+
+## Store Adapter
+
+A concrete implementation of the Credential Store interface.
+Production uses the OS keyring adapter; tests use the in-memory fake.
+
+## Env Override
+
+The rule that `WEATHER_API_KEY` beats the stored key when reading.
+It affects reads only: setup still writes to the keyring and delete-key still deletes from it while the env var is set.
+Precedence is a Credential Store concern, not a config concern.
+
+## Availability
+
+Whether the OS keyring can actually be used at runtime (e.g. present dbus/Secret Service on Linux), probed before prompting so users on unsupported systems are routed to the env var without typing a key.
+
+## Setup Wizard
+
+The interactive flow behind `weather-cli setup`: checks Availability, prompts for a key, stores it via the Credential Store.

--- a/internal/cli/setup.go
+++ b/internal/cli/setup.go
@@ -1,25 +1,56 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
+	"os"
+	"strings"
 
+	"golang.org/x/term"
+
+	"github.com/jtotty/weather-cli/internal/config"
 	"github.com/jtotty/weather-cli/internal/credentials"
 )
 
-func RunSetup() error {
-	if !credentials.IsKeyringAvailable() {
+// KeyReader reads an API key from the user.
+type KeyReader func() (string, error)
+
+// ReadKeyFromTerminal is the production KeyReader: it prompts on stdout and
+// reads the key from the terminal without echoing it.
+func ReadKeyFromTerminal() (string, error) {
+	fmt.Print("Enter your Weather API key: ")
+
+	keyBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
+	fmt.Println()
+
+	if err != nil {
+		return "", fmt.Errorf("failed to read API key: %w", err)
+	}
+
+	key := strings.TrimSpace(string(keyBytes))
+	if key == "" {
+		return "", errors.New("API key cannot be empty")
+	}
+
+	return key, nil
+}
+
+// RunSetup is the setup wizard: it checks store availability, prompts for a
+// key via input, and stores it.
+func RunSetup(store credentials.Store, input KeyReader) error {
+	if !store.Available() {
 		return fmt.Errorf("OS keyring is not available on this system. Set WEATHER_API_KEY environment variable instead")
 	}
 
 	fmt.Println("Get a free API key from https://www.weatherapi.com/")
 	fmt.Println()
 
-	key, err := credentials.PromptForAPIKey()
+	key, err := input()
 	if err != nil {
 		return err
 	}
 
-	if err := credentials.SetAPIKey(key); err != nil {
+	if err := store.Set(key); err != nil {
 		return err
 	}
 
@@ -27,10 +58,30 @@ func RunSetup() error {
 	return nil
 }
 
-func RunDeleteKey() error {
-	if err := credentials.DeleteAPIKey(); err != nil {
+func RunDeleteKey(store credentials.Store) error {
+	if err := store.Delete(); err != nil {
 		return err
 	}
 	fmt.Println("API key deleted from keyring.")
 	return nil
+}
+
+// LoadConfig loads the app config, guiding the user through setup when no
+// API key is configured yet.
+func LoadConfig(store credentials.Store, input KeyReader) (*config.Config, error) {
+	cfg, err := config.New(store)
+	if err == nil {
+		return cfg, nil
+	}
+
+	if errors.Is(err, credentials.ErrNoAPIKey) {
+		fmt.Println("No API key configured.")
+		fmt.Println()
+		if setupErr := RunSetup(store, input); setupErr != nil {
+			return nil, fmt.Errorf("setup failed: %w", setupErr)
+		}
+		return config.New(store)
+	}
+
+	return nil, fmt.Errorf("error loading config: %w", err)
 }

--- a/internal/cli/setup_test.go
+++ b/internal/cli/setup_test.go
@@ -1,0 +1,100 @@
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jtotty/weather-cli/internal/credentials"
+)
+
+const testKey = "my-key"
+
+func fakeInput(key string) KeyReader {
+	return func() (string, error) { return key, nil }
+}
+
+func TestRunSetup_StoresKeyFromInput(t *testing.T) {
+	store := &credentials.Fake{}
+
+	if err := RunSetup(store, fakeInput(testKey)); err != nil {
+		t.Fatalf("RunSetup() error = %v", err)
+	}
+
+	key, err := store.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if key != testKey {
+		t.Errorf("stored key = %q, want %q", key, testKey)
+	}
+}
+
+func TestRunSetup_ErrorsWhenStoreUnavailable(t *testing.T) {
+	store := &credentials.Fake{Unavailable: true}
+
+	err := RunSetup(store, fakeInput(testKey))
+	if err == nil {
+		t.Fatal("RunSetup() should error when the store is unavailable")
+	}
+
+	store.Unavailable = false
+	if _, getErr := store.Get(); !errors.Is(getErr, credentials.ErrNoAPIKey) {
+		t.Error("no key should be stored when the store is unavailable")
+	}
+}
+
+func TestRunSetup_PropagatesInputError(t *testing.T) {
+	store := &credentials.Fake{}
+	inputErr := errors.New("read failed")
+	input := func() (string, error) { return "", inputErr }
+
+	if err := RunSetup(store, input); !errors.Is(err, inputErr) {
+		t.Errorf("RunSetup() error = %v, want %v", err, inputErr)
+	}
+}
+
+func TestRunDeleteKey_RemovesStoredKey(t *testing.T) {
+	store := &credentials.Fake{Key: testKey}
+
+	if err := RunDeleteKey(store); err != nil {
+		t.Fatalf("RunDeleteKey() error = %v", err)
+	}
+
+	if _, err := store.Get(); !errors.Is(err, credentials.ErrNoAPIKey) {
+		t.Errorf("Get() after RunDeleteKey() error = %v, want ErrNoAPIKey", err)
+	}
+}
+
+func TestLoadConfig_ReturnsConfigWhenKeyPresent(t *testing.T) {
+	store := &credentials.Fake{Key: testKey}
+
+	cfg, err := LoadConfig(store, fakeInput("unused"))
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.APIKey != testKey {
+		t.Errorf("APIKey = %q, want %q", cfg.APIKey, testKey)
+	}
+}
+
+func TestLoadConfig_MissingKeyRunsSetup(t *testing.T) {
+	store := &credentials.Fake{}
+
+	cfg, err := LoadConfig(store, fakeInput("new-key"))
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+	if cfg.APIKey != "new-key" {
+		t.Errorf("APIKey = %q, want %q", cfg.APIKey, "new-key")
+	}
+}
+
+func TestLoadConfig_MissingKeyAndFailedSetupReturnsError(t *testing.T) {
+	store := &credentials.Fake{}
+	inputErr := errors.New("read failed")
+	input := func() (string, error) { return "", inputErr }
+
+	if _, err := LoadConfig(store, input); !errors.Is(err, inputErr) {
+		t.Errorf("LoadConfig() error = %v, want %v", err, inputErr)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,7 +14,7 @@ type Config struct {
 	IsLocal    bool
 }
 
-func New() (*Config, error) {
+func New(store credentials.Store) (*Config, error) {
 	cfg := &Config{
 		Location:   "auto:ip",
 		Days:       7,
@@ -23,7 +23,7 @@ func New() (*Config, error) {
 		IsLocal:    true,
 	}
 
-	apiKey, err := credentials.GetAPIKey()
+	apiKey, err := store.Get()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,28 +1,37 @@
 package config
 
 import (
+	"errors"
 	"testing"
+
+	"github.com/jtotty/weather-cli/internal/credentials"
 )
 
-func TestNew_WithEnvAPIKey(t *testing.T) {
-	t.Setenv("WEATHER_API_KEY", "test-api-key")
+func TestNew_UsesKeyFromStore(t *testing.T) {
+	store := &credentials.Fake{Key: "test-api-key"}
 
-	cfg, err := New()
+	cfg, err := New(store)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if cfg == nil {
-		t.Fatal("expected config, got nil")
 	}
 	if cfg.APIKey != "test-api-key" {
 		t.Errorf("APIKey = %q, want %q", cfg.APIKey, "test-api-key")
 	}
 }
 
-func TestNew_DefaultValues(t *testing.T) {
-	t.Setenv("WEATHER_API_KEY", "test-key")
+func TestNew_MissingKeyReturnsErrNoAPIKey(t *testing.T) {
+	store := &credentials.Fake{}
 
-	cfg, err := New()
+	_, err := New(store)
+	if !errors.Is(err, credentials.ErrNoAPIKey) {
+		t.Errorf("New() error = %v, want ErrNoAPIKey", err)
+	}
+}
+
+func TestNew_DefaultValues(t *testing.T) {
+	store := &credentials.Fake{Key: "test-key"}
+
+	cfg, err := New(store)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -45,9 +54,9 @@ func TestNew_DefaultValues(t *testing.T) {
 }
 
 func TestSetLocation_SetsIsLocalFalse(t *testing.T) {
-	t.Setenv("WEATHER_API_KEY", "test-key")
+	store := &credentials.Fake{Key: "test-key"}
 
-	cfg, err := New()
+	cfg, err := New(store)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -1,4 +1,5 @@
-// Package credentials provides secure storage for API keys using the OS keyring.
+// Package credentials owns where the API key lives: retrieval, storage,
+// deletion, availability, and precedence between sources.
 package credentials
 
 import (
@@ -8,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/zalando/go-keyring"
-	"golang.org/x/term"
 )
 
 const (
@@ -22,11 +22,23 @@ var (
 	ErrKeyringUnavailable = errors.New("OS keyring unavailable")
 )
 
-func GetAPIKey() (string, error) {
-	if key := os.Getenv(envVarName); key != "" {
-		return key, nil
-	}
+// Store is the credential store seam: the single answer to where the API key
+// comes from.
+type Store interface {
+	Get() (string, error)
+	Set(key string) error
+	Delete() error
+	Available() bool
+}
 
+// Keyring is the production Store adapter backed by the OS keyring.
+type Keyring struct{}
+
+func NewKeyring() *Keyring {
+	return &Keyring{}
+}
+
+func (k *Keyring) Get() (string, error) {
 	key, err := keyring.Get(serviceName, apiKeyName)
 	if err == nil && key != "" {
 		return key, nil
@@ -47,10 +59,20 @@ func GetAPIKey() (string, error) {
 	return "", ErrNoAPIKey
 }
 
-func SetAPIKey(key string) error {
+// normalizeKey trims a key and rejects blank ones, so every Store adapter
+// shares the same write semantics.
+func normalizeKey(key string) (string, error) {
 	key = strings.TrimSpace(key)
 	if key == "" {
-		return errors.New("API key cannot be empty")
+		return "", errors.New("API key cannot be empty")
+	}
+	return key, nil
+}
+
+func (k *Keyring) Set(key string) error {
+	key, err := normalizeKey(key)
+	if err != nil {
+		return err
 	}
 
 	if err := keyring.Set(serviceName, apiKeyName, key); err != nil {
@@ -63,7 +85,7 @@ func SetAPIKey(key string) error {
 	return nil
 }
 
-func DeleteAPIKey() error {
+func (k *Keyring) Delete() error {
 	if err := keyring.Delete(serviceName, apiKeyName); err != nil {
 		if errors.Is(err, keyring.ErrNotFound) {
 			return nil
@@ -73,33 +95,40 @@ func DeleteAPIKey() error {
 	return nil
 }
 
-func PromptForAPIKey() (string, error) {
-	fmt.Print("Enter your Weather API key: ")
-
-	keyBytes, err := term.ReadPassword(int(os.Stdin.Fd()))
-	fmt.Println()
-
-	if err != nil {
-		return "", fmt.Errorf("failed to read API key: %w", err)
-	}
-
-	key := strings.TrimSpace(string(keyBytes))
-	if key == "" {
-		return "", errors.New("API key cannot be empty")
-	}
-
-	return key, nil
-}
-
-func IsKeyringAvailable() bool {
+func (k *Keyring) Available() bool {
 	_, err := keyring.Get(serviceName, "test-availability")
 	if err == nil {
 		return true
 	}
 
-	if errors.Is(err, keyring.ErrNotFound) {
-		return true
-	}
+	return errors.Is(err, keyring.ErrNotFound)
+}
 
-	return false
+// EnvOverride decorates a Store so WEATHER_API_KEY beats the stored key on
+// reads. Set, Delete, and Available pass through to the inner store.
+type EnvOverride struct {
+	inner Store
+}
+
+func NewEnvOverride(inner Store) *EnvOverride {
+	return &EnvOverride{inner: inner}
+}
+
+func (e *EnvOverride) Get() (string, error) {
+	if key := os.Getenv(envVarName); key != "" {
+		return key, nil
+	}
+	return e.inner.Get()
+}
+
+func (e *EnvOverride) Set(key string) error {
+	return e.inner.Set(key)
+}
+
+func (e *EnvOverride) Delete() error {
+	return e.inner.Delete()
+}
+
+func (e *EnvOverride) Available() bool {
+	return e.inner.Available()
 }

--- a/internal/credentials/credentials_test.go
+++ b/internal/credentials/credentials_test.go
@@ -1,0 +1,165 @@
+package credentials
+
+import (
+	"errors"
+	"testing"
+)
+
+const testKey = "my-key"
+
+func TestFake_GetReturnsErrNoAPIKeyWhenEmpty(t *testing.T) {
+	fake := &Fake{}
+
+	_, err := fake.Get()
+	if !errors.Is(err, ErrNoAPIKey) {
+		t.Errorf("Get() error = %v, want ErrNoAPIKey", err)
+	}
+}
+
+func TestFake_SetThenGetRoundTrips(t *testing.T) {
+	fake := &Fake{}
+
+	if err := fake.Set(testKey); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	key, err := fake.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if key != testKey {
+		t.Errorf("Get() = %q, want %q", key, testKey)
+	}
+}
+
+func TestFake_SetTrimsWhitespace(t *testing.T) {
+	fake := &Fake{}
+
+	if err := fake.Set("  my-key  "); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	key, _ := fake.Get()
+	if key != testKey {
+		t.Errorf("Get() = %q, want %q", key, testKey)
+	}
+}
+
+func TestFake_SetRejectsEmptyKey(t *testing.T) {
+	fake := &Fake{}
+
+	if err := fake.Set("   "); err == nil {
+		t.Error("Set() with blank key should return an error")
+	}
+}
+
+func TestFake_DeleteRemovesKey(t *testing.T) {
+	fake := &Fake{}
+	if err := fake.Set(testKey); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	if err := fake.Delete(); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+
+	_, err := fake.Get()
+	if !errors.Is(err, ErrNoAPIKey) {
+		t.Errorf("Get() after Delete() error = %v, want ErrNoAPIKey", err)
+	}
+}
+
+func TestFake_DeleteWithoutKeyIsNoError(t *testing.T) {
+	fake := &Fake{}
+
+	if err := fake.Delete(); err != nil {
+		t.Errorf("Delete() on empty store error = %v, want nil", err)
+	}
+}
+
+func TestFake_UnavailableFailsEveryOperation(t *testing.T) {
+	fake := &Fake{Key: testKey, Unavailable: true}
+
+	if _, err := fake.Get(); !errors.Is(err, ErrKeyringUnavailable) {
+		t.Errorf("Get() error = %v, want ErrKeyringUnavailable", err)
+	}
+	if err := fake.Set("other-key"); !errors.Is(err, ErrKeyringUnavailable) {
+		t.Errorf("Set() error = %v, want ErrKeyringUnavailable", err)
+	}
+	if err := fake.Delete(); !errors.Is(err, ErrKeyringUnavailable) {
+		t.Errorf("Delete() error = %v, want ErrKeyringUnavailable", err)
+	}
+}
+
+func TestFake_Available(t *testing.T) {
+	fake := &Fake{}
+	if !fake.Available() {
+		t.Error("Available() = false, want true by default")
+	}
+
+	fake.Unavailable = true
+	if fake.Available() {
+		t.Error("Available() = true, want false when Unavailable is set")
+	}
+}
+
+func TestEnvOverride_EnvVarBeatsStoredKey(t *testing.T) {
+	t.Setenv("WEATHER_API_KEY", "env-key")
+
+	fake := &Fake{}
+	if err := fake.Set("stored-key"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	store := NewEnvOverride(fake)
+
+	key, err := store.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if key != "env-key" {
+		t.Errorf("Get() = %q, want %q", key, "env-key")
+	}
+}
+
+func TestEnvOverride_FallsBackToInnerStore(t *testing.T) {
+	t.Setenv("WEATHER_API_KEY", "")
+
+	fake := &Fake{}
+	if err := fake.Set("stored-key"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	store := NewEnvOverride(fake)
+
+	key, err := store.Get()
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if key != "stored-key" {
+		t.Errorf("Get() = %q, want %q", key, "stored-key")
+	}
+}
+
+func TestEnvOverride_SetDeleteAvailablePassThrough(t *testing.T) {
+	t.Setenv("WEATHER_API_KEY", "env-key")
+
+	fake := &Fake{}
+	store := NewEnvOverride(fake)
+
+	if err := store.Set("stored-key"); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+	if key, err := fake.Get(); err != nil || key != "stored-key" {
+		t.Errorf("inner store Get() = %q, %v, want %q", key, err, "stored-key")
+	}
+
+	if !store.Available() {
+		t.Error("Available() = false, want passthrough true")
+	}
+
+	if err := store.Delete(); err != nil {
+		t.Fatalf("Delete() error = %v", err)
+	}
+	if _, err := fake.Get(); !errors.Is(err, ErrNoAPIKey) {
+		t.Errorf("inner store Get() after Delete() error = %v, want ErrNoAPIKey", err)
+	}
+}

--- a/internal/credentials/fake.go
+++ b/internal/credentials/fake.go
@@ -1,0 +1,44 @@
+package credentials
+
+// Fake is an in-memory Store adapter for tests. It mirrors the keyring
+// adapter's semantics: keys are trimmed, blank keys are rejected, a missing
+// key reads as ErrNoAPIKey, and every operation fails with
+// ErrKeyringUnavailable when Unavailable is set.
+type Fake struct {
+	Key         string
+	Unavailable bool
+}
+
+func (f *Fake) Get() (string, error) {
+	if f.Unavailable {
+		return "", ErrKeyringUnavailable
+	}
+	if f.Key == "" {
+		return "", ErrNoAPIKey
+	}
+	return f.Key, nil
+}
+
+func (f *Fake) Set(key string) error {
+	if f.Unavailable {
+		return ErrKeyringUnavailable
+	}
+	key, err := normalizeKey(key)
+	if err != nil {
+		return err
+	}
+	f.Key = key
+	return nil
+}
+
+func (f *Fake) Delete() error {
+	if f.Unavailable {
+		return ErrKeyringUnavailable
+	}
+	f.Key = ""
+	return nil
+}
+
+func (f *Fake) Available() bool {
+	return !f.Unavailable
+}

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 
 	"github.com/jtotty/weather-cli/internal/cli"
-	"github.com/jtotty/weather-cli/internal/config"
 	"github.com/jtotty/weather-cli/internal/credentials"
 	"github.com/jtotty/weather-cli/internal/service"
 	"github.com/jtotty/weather-cli/internal/weather"
@@ -18,6 +17,7 @@ var version = "dev"
 
 func main() {
 	cmd := cli.Parse(os.Args)
+	store := credentials.NewEnvOverride(credentials.NewKeyring())
 
 	switch cmd.Type {
 	case cli.CommandHelp:
@@ -25,22 +25,22 @@ func main() {
 	case cli.CommandVersion:
 		cli.PrintVersion(version)
 	case cli.CommandSetup:
-		if err := cli.RunSetup(); err != nil {
+		if err := cli.RunSetup(store, cli.ReadKeyFromTerminal); err != nil {
 			cli.ExitWithError(fmt.Errorf("setup failed: %w", err))
 		}
 	case cli.CommandDeleteKey:
-		if err := cli.RunDeleteKey(); err != nil {
+		if err := cli.RunDeleteKey(store); err != nil {
 			cli.ExitWithError(fmt.Errorf("failed to delete API key: %w", err))
 		}
 	case cli.CommandWeather:
 		ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 		defer cancel()
-		runWeather(ctx, cmd.Location)
+		runWeather(ctx, store, cmd.Location)
 	}
 }
 
-func runWeather(ctx context.Context, location string) {
-	cfg, err := loadConfig()
+func runWeather(ctx context.Context, store credentials.Store, location string) {
+	cfg, err := cli.LoadConfig(store, cli.ReadKeyFromTerminal)
 	if err != nil {
 		cli.ExitWithError(err)
 	}
@@ -65,22 +65,4 @@ func runWeather(ctx context.Context, location string) {
 	}
 
 	display.Render()
-}
-
-func loadConfig() (*config.Config, error) {
-	cfg, err := config.New()
-	if err == nil {
-		return cfg, nil
-	}
-
-	if errors.Is(err, credentials.ErrNoAPIKey) {
-		fmt.Println("No API key configured.")
-		fmt.Println()
-		if setupErr := cli.RunSetup(); setupErr != nil {
-			return nil, fmt.Errorf("setup failed: %w", setupErr)
-		}
-		return config.New()
-	}
-
-	return nil, fmt.Errorf("error loading config: %w", err)
 }


### PR DESCRIPTION
Implements ticket 02 (credential store seam) from `.scratch/architecture-deepening/issues/`.

## What changed

- `internal/credentials` defines a `Store` interface (`Get`, `Set`, `Delete`, `Available`) with three implementations: the OS `Keyring` adapter, an `EnvOverride` decorator applying `WEATHER_API_KEY` precedence to reads only, and an exported in-memory `Fake` for tests.
- The key prompt moved out of credentials: `cli.RunSetup(store, input)` takes an injectable `KeyReader` (`ReadKeyFromTerminal` in production).
- `loadConfig` moved from `main.go` to `cli.LoadConfig(store, input)` so the missing-key branch is testable; `main.go` is pure wiring.
- New tests through the fake: fake contract, env precedence/passthrough, config loading, setup and delete-key flows, missing-key branch.
- Commits `CONTEXT.md` (domain glossary these terms come from) and updates stale `credentials.Get()` references in `AGENTS.md`.

User-visible behaviour is unchanged: setup, delete-key, env-var precedence, and the guided missing-key message all work as before.

## Verification

- `go test -race ./...` and `golangci-lint run` (CI-pinned v2.6.2) pass.
- Driven end-to-end: bogus `WEATHER_API_KEY` reaches the API (401, proving env precedence), keyring-backed fetch works, `--setup` on a non-tty fails cleanly before any keyring write.

🤖 Generated with [Claude Code](https://claude.com/claude-code)